### PR TITLE
Remove FastMath - seems to make things slower

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,6 @@ version := "0.1"
 scalaVersion := "2.12.6"
 
 libraryDependencies ++= Seq(
-  "org.apache.commons" % "commons-math3" % "3.6.1",
   "org.scalatest" %% "scalatest" % "3.0.5" % "test"
 )
 

--- a/src/main/scala/uk/carwynellis/raytracing/Camera.scala
+++ b/src/main/scala/uk/carwynellis/raytracing/Camera.scala
@@ -1,7 +1,5 @@
 package uk.carwynellis.raytracing
 
-import org.apache.commons.math3.util.FastMath
-
 import scala.annotation.tailrec
 
 /**
@@ -28,7 +26,7 @@ class Camera(origin: Vec3,
   private val lensRadius = aperture / 2.0
 
   private val theta = verticalFieldOfView * (math.Pi/180.0)
-  private val halfHeight = FastMath.tan(theta/2.0)
+  private val halfHeight = Math.tan(theta/2.0)
   private val halfWidth = aspectRatio * halfHeight
 
   private val w = (origin - target).unitVector

--- a/src/main/scala/uk/carwynellis/raytracing/Render.scala
+++ b/src/main/scala/uk/carwynellis/raytracing/Render.scala
@@ -6,7 +6,7 @@ object Render extends App {
 
   val width = 1200
   val height = 800
-  val samples = 100
+  val samples = 10
 
   val origin = Vec3(478, 278, -600)
   val target = Vec3(278, 278, 0)

--- a/src/main/scala/uk/carwynellis/raytracing/Vec3.scala
+++ b/src/main/scala/uk/carwynellis/raytracing/Vec3.scala
@@ -1,7 +1,5 @@
 package uk.carwynellis.raytracing
 
-import org.apache.commons.math3.util.FastMath
-
 /**
   * Partial implementation of the Vec3 class from chapter 2 of ray tracing in one weekend.
   *
@@ -64,7 +62,7 @@ case class Vec3(x: Double, y: Double, z: Double) {
     *
     * @return
     */
-  def squaredLength: Double = FastMath.pow(x, 2) + FastMath.pow(y, 2) + FastMath.pow(z, 2)
+  def squaredLength: Double = Math.pow(x, 2) + Math.pow(y, 2) + Math.pow(z, 2)
 
   // TODO - stream operators >> and << not yet implemented.
 

--- a/src/main/scala/uk/carwynellis/raytracing/hitable/ConstantMedium.scala
+++ b/src/main/scala/uk/carwynellis/raytracing/hitable/ConstantMedium.scala
@@ -1,5 +1,4 @@
 package uk.carwynellis.raytracing.hitable
-import org.apache.commons.math3.util.FastMath
 import uk.carwynellis.raytracing.material.IsoTropic
 import uk.carwynellis.raytracing.texture.Texture
 import uk.carwynellis.raytracing.{AxisAlignedBoundingBox, HitRecord, Ray, Vec3}
@@ -19,7 +18,7 @@ class ConstantMedium(boundary: Hitable, density: Double, albedo: Texture) extend
         else {
           val boundedT1 = if (t1 < 0) 0 else t1
           val distanceInsideBoundary = (t2 - boundedT1) * r.direction.length
-          val hitDistance = -(1/density) * FastMath.log(math.random())
+          val hitDistance = -(1/density) * Math.log(math.random())
           if (hitDistance < distanceInsideBoundary) {
             val hitT: Double = boundedT1 + hitDistance / r.direction.length
             Some(HitRecord(

--- a/src/main/scala/uk/carwynellis/raytracing/hitable/Sphere.scala
+++ b/src/main/scala/uk/carwynellis/raytracing/hitable/Sphere.scala
@@ -1,6 +1,5 @@
 package uk.carwynellis.raytracing.hitable
 
-import org.apache.commons.math3.util.FastMath
 import uk.carwynellis.raytracing._
 import uk.carwynellis.raytracing.material.Material
 
@@ -17,7 +16,7 @@ class Sphere(val centre: Vec3, val radius: Double, val material: Material) exten
     val b = oc.dot(r.direction)
     val c = oc.dot(oc) - (radius * radius)
 
-    val discriminant = FastMath.pow(b, 2) - (a * c)
+    val discriminant = Math.pow(b, 2) - (a * c)
 
     if (discriminant > 0) {
       val discriminantRoot = math.sqrt(discriminant)
@@ -87,8 +86,8 @@ object Sphere {
     * @return
     */
   def getSphereUV(p: Vec3): (Double, Double) = {
-    val phi = FastMath.atan2(p.z, p.x)
-    val theta = FastMath.asin(p.y)
+    val phi = Math.atan2(p.z, p.x)
+    val theta = Math.asin(p.y)
     val u = 1 - (phi + math.Pi) / (2 * math.Pi)
     val v = (theta + math.Pi/2) / math.Pi
     (u, v)

--- a/src/main/scala/uk/carwynellis/raytracing/hitable/transform/RotateY.scala
+++ b/src/main/scala/uk/carwynellis/raytracing/hitable/transform/RotateY.scala
@@ -1,6 +1,5 @@
 package uk.carwynellis.raytracing.hitable.transform
 
-import org.apache.commons.math3.util.FastMath
 import uk.carwynellis.raytracing.{AxisAlignedBoundingBox, HitRecord, Ray, Vec3}
 import uk.carwynellis.raytracing.hitable.Hitable
 
@@ -8,8 +7,8 @@ class RotateY(p: Hitable, angle: Double) extends Hitable {
 
   private val angleRadians = (math.Pi / 180) * angle
 
-  private val sinTheta = FastMath.sin(angleRadians)
-  private val cosTheta = FastMath.cos(angleRadians)
+  private val sinTheta = Math.sin(angleRadians)
+  private val cosTheta = Math.cos(angleRadians)
 
   private val boundingBox = p.boundingBox(0, 1).map { box =>
       // TODO - express this without vars

--- a/src/main/scala/uk/carwynellis/raytracing/material/Dielectric.scala
+++ b/src/main/scala/uk/carwynellis/raytracing/material/Dielectric.scala
@@ -1,6 +1,5 @@
 package uk.carwynellis.raytracing.material
 
-import org.apache.commons.math3.util.FastMath
 import uk.carwynellis.raytracing.{HitRecord, Ray, Vec3}
 import uk.carwynellis.raytracing.texture.ConstantTexture
 
@@ -39,7 +38,7 @@ class Dielectric(refractiveIndex: Double) extends Material(ConstantTexture(Vec3(
   private def schlick(cosine: Double): Double = {
     val r0 = (1 - refractiveIndex) / (1 + refractiveIndex)
     val r0Squared = r0 * r0
-    r0Squared + (1 - r0Squared) * FastMath.pow(1 - cosine, 5)
+    r0Squared + (1 - r0Squared) * Math.pow(1 - cosine, 5)
   }
 }
 

--- a/src/main/scala/uk/carwynellis/raytracing/texture/CheckerBoard.scala
+++ b/src/main/scala/uk/carwynellis/raytracing/texture/CheckerBoard.scala
@@ -1,5 +1,4 @@
 package uk.carwynellis.raytracing.texture
-import org.apache.commons.math3.util.FastMath
 import uk.carwynellis.raytracing.Vec3
 
 /**
@@ -24,7 +23,7 @@ class CheckerBoard(odd: Texture, even: Texture) extends Texture {
     * @return
     */
   override def value(u: Double, v: Double, p: Vec3): Vec3 = {
-    val sines = FastMath.sin(10 * p.x) * FastMath.sin(10 * p.y) * FastMath.sin(10 * p.z)
+    val sines = Math.sin(10 * p.x) * Math.sin(10 * p.y) * Math.sin(10 * p.z)
     if (sines < 0) odd.value(u, v, p)
     else even.value(u, v, p)
   }

--- a/src/main/scala/uk/carwynellis/raytracing/texture/NoiseTexture.scala
+++ b/src/main/scala/uk/carwynellis/raytracing/texture/NoiseTexture.scala
@@ -1,5 +1,4 @@
 package uk.carwynellis.raytracing.texture
-import org.apache.commons.math3.util.FastMath
 import uk.carwynellis.raytracing.Vec3
 
 class NoiseTexture(scale: Double) extends Texture {
@@ -7,7 +6,7 @@ class NoiseTexture(scale: Double) extends Texture {
   private val perlinNoise = new Perlin
 
   override def value(u: Double, v: Double, p: Vec3): Vec3 =
-    Vec3(1,1,1) * 0.5 * (1 + FastMath.sin(scale * p.x + 5 * perlinNoise.turbulence(scale * p)))
+    Vec3(1,1,1) * 0.5 * (1 + Math.sin(scale * p.x + 5 * perlinNoise.turbulence(scale * p)))
 }
 
 object NoiseTexture {

--- a/src/main/scala/uk/carwynellis/raytracing/texture/Perlin.scala
+++ b/src/main/scala/uk/carwynellis/raytracing/texture/Perlin.scala
@@ -1,6 +1,5 @@
 package uk.carwynellis.raytracing.texture
 
-import org.apache.commons.math3.util.FastMath
 import uk.carwynellis.raytracing.Vec3
 
 import scala.annotation.tailrec
@@ -16,14 +15,14 @@ class Perlin {
   private val randomValues = generateNoise()
 
   def noise(p: Vec3): Double = {
-    val u = p.x - FastMath.floor(p.x)
-    val v = p.y - FastMath.floor(p.y)
-    val w = p.z - FastMath.floor(p.z)
+    val u = p.x - Math.floor(p.x)
+    val v = p.y - Math.floor(p.y)
+    val w = p.z - Math.floor(p.z)
 
 
-    val i = FastMath.floor(p.x).toInt
-    val j = FastMath.floor(p.y).toInt
-    val k = FastMath.floor(p.z).toInt
+    val i = Math.floor(p.x).toInt
+    val j = Math.floor(p.y).toInt
+    val k = Math.floor(p.z).toInt
 
     val c = ArrayBuffer.fill(2, 2, 2)(Vec3(0, 0, 0))
 
@@ -42,7 +41,7 @@ class Perlin {
   def turbulence(p: Vec3, iterations: Int = 7): Double = {
     @tailrec
     def loop(acc: Double, weight: Double, q: Vec3, count: Int): Double = {
-      if (count >= iterations) FastMath.abs(acc)
+      if (count >= iterations) Math.abs(acc)
       else loop(acc + weight * noise(q), weight * 0.5, q * 2, count + 1)
     }
 


### PR DESCRIPTION
* visualvm suggests that fastmath adds additional object allocation
overheads (to that already imposed by the number of Vec3s that are
created and disposed)
* timings suggest that the fastmath implementation is in fact slower
because of this